### PR TITLE
Fix docs for trial-evaluation

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,6 +3,6 @@
     "Introduction": ["why-ax"],
     "Getting Started": ["installation", "api", "glossary"],
     "Algorithms": ["bayesopt", "banditopt"],
-    "Components": ["core", "runner", "data", "models", "storage"]
+    "Components": ["core", "trial-evaluation", "data", "models", "storage"]
   }
 }


### PR DESCRIPTION
runners.md was renamed to trial-evaluation.md which broke the website sidenav and next/prev buttons. This change should fix that.